### PR TITLE
Fix: only import functions that are needed from lodash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,8 @@
 Object.defineProperty(exports, "__esModule", {
 		value: true
 });
-var _ = require("lodash");
+var get = require("lodash/fp/get");
+var kebabCase = require("lodash/fp/kebabCase");
 var moment = require("moment");
 
 // function charHash(string) {
@@ -36,7 +37,7 @@ var getDatePath = function getDatePath(date) {
 		return moment(date).isValid() ? moment(date).format(formatDate) : "";
 };
 var getOptionsPath = function getOptionsPath(options, prop) {
-		return _.get(options, "" + prop);
+		return get("" + prop, options);
 };
 // const getOptionsPath = (options,prop) =>Format(_.get(options,`${prop}`));
 
@@ -50,10 +51,10 @@ exports.default = function (str) {
 
 
 		str = str.toString();
-		var format = _.get(options, "format");
+		var format = get("format", options);
 
-		if (format === "kebabCase") return _.kebabCase(str);
-		if (format === "charHash") return _.charHash(str);
+		if (format === "kebabCase") return kebabCase(str);
+		if (format === "charHash") return charHash(str);
 
 		var numberHash = createNumberHash(str);
 		var letterHash = createLetterHash(numberHash);
@@ -61,7 +62,7 @@ exports.default = function (str) {
 		var appendString = getOptionsPath(options, "append");
 		appendString = appendString ? "/" + appendString : "";
 
-		var date = _.get(options, "date");
+		var date = get("date", options);
 		var hashId = getOptionsPath(options, "hashId");
 		if (!hashId) {
 				if (format === "string") hashId = letterHash;else hashId = numberHash;
@@ -86,7 +87,7 @@ exports.default = function (str) {
 
 
 var createNumberHash = function createNumberHash(str) {
-		str = _.kebabCase(str);
+		str = kebabCase(str);
 		var hash = 0,
 		    i,
 		    chr,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unique-hash",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Generate a unique and repeatable hash id for strings like names and urls",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-var _=require("lodash")
+var get=require("lodash/fp/get")
+var kebabCase=require("lodash/fp/kebabCase")
 var moment=require("moment")
 
 
@@ -26,7 +27,7 @@ const charHash = (string) => {
 
 const Format = (path) => (path)?path+"/":"";
 const getDatePath = (date,formatDate="YYYY/MM/DD") =>(moment(date).isValid())?moment(date).format(formatDate):"";
-const getOptionsPath = (options,prop) =>_.get(options,`${prop}`);
+const getOptionsPath = (options,prop) =>get(`${prop}`,options);
 // const getOptionsPath = (options,prop) =>Format(_.get(options,`${prop}`));
 
 
@@ -38,10 +39,10 @@ export default (str,options={}) => {
 
 
 str=str.toString()
-let format=_.get(options,"format")
+let format=get("format",options)
 
-if(format==="kebabCase")return _.kebabCase(str)
-if(format==="charHash")return _.charHash(str)
+if(format==="kebabCase")return kebabCase(str)
+if(format==="charHash")return charHash(str)
 
 let numberHash=createNumberHash(str)
 let letterHash=createLetterHash(numberHash)
@@ -50,7 +51,7 @@ let letterHash=createLetterHash(numberHash)
 let appendString=getOptionsPath(options,"append")
 appendString=(appendString)?"/"+appendString:""
 
-let date=_.get(options,"date")
+let date=get("date",options)
 let hashId=getOptionsPath(options,"hashId")
 if(!hashId){
 if(format==="string")hashId=letterHash
@@ -84,7 +85,7 @@ return path
 * @return {number} - Unique Number
 */
 	const createNumberHash=(str)=>{
-	    str=_.kebabCase(str)
+	    str=kebabCase(str)
 	  var hash = 0, i, chr, len;
 	  if (str.length === 0) return hash;
 	  for (i = 0, len = str.length; i < len; i++) {


### PR DESCRIPTION
This is a non breaking change that fixes imports to only include functions from lodash that are actually used instead of importing all of them. This reduces the bundle size for applications that are using unique-hash as a dependency.

I tested the change with the examples in the README and they worked identically after the refactor.